### PR TITLE
Update requirements.txt

### DIFF
--- a/lib/utils/waymo_utils.py
+++ b/lib/utils/waymo_utils.py
@@ -697,8 +697,8 @@ def generate_dataparser_outputs(
         #     pass
 
 
-        result['points_xyz_dict'] = points_xyz_dict
-        result['points_rgb_dict'] = points_rgb_dict
+        # result['points_xyz_dict'] = points_xyz_dict
+        # result['points_rgb_dict'] = points_rgb_dict
 
         for k in points_xyz_dict.keys():
             points_xyz = points_xyz_dict[k]

--- a/lib/visualizers/street_gaussian_visualizer.py
+++ b/lib/visualizers/street_gaussian_visualizer.py
@@ -9,11 +9,9 @@ from lib.utils.camera_utils import Camera
 from lib.utils.img_utils import visualize_depth_numpy
 from lib.config import cfg
 
-class StreetGaussianisualizer():
+class StreetGaussianVisualizer():
     def __init__(self, save_dir):
         
-        if cfg.render.edit:
-            save_dir = save_dir + '_edit'
         self.result_dir = save_dir
         os.makedirs(self.result_dir, exist_ok=True)
         

--- a/render.py
+++ b/render.py
@@ -9,7 +9,7 @@ from lib.models.scene import Scene
 from lib.utils.general_utils import safe_state
 from lib.config import cfg
 from lib.visualizers.base_visualizer import BaseVisualizer as Visualizer
-from lib.visualizers.street_gaussian_visualizer import StreetGaussianisualizer
+from lib.visualizers.street_gaussian_visualizer import StreetGaussianVisualizer
 import time
 
 def render_sets():
@@ -71,7 +71,7 @@ def render_trajectory():
         renderer = StreetGaussianRenderer()
         
         save_dir = os.path.join(cfg.model_path, 'trajectory', "ours_{}".format(scene.loaded_iter))
-        visualizer = StreetGaussianisualizer(save_dir)
+        visualizer = StreetGaussianVisualizer(save_dir)
         
         train_cameras = scene.getTrainCameras()
         test_cameras = scene.getTestCameras()

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ lpips
 plyfile
 tensorboard
 sympy
-numpy
+numpy==1.23.5
 pillow
 matplotlib
 bidict


### PR DESCRIPTION
Hi,

It seems that an error `TypeError: No loop matching the specified signature and casting was found for ufunc greater` occurred during training when the following line was executed:

https://github.com/zju3dv/street_gaussians/blob/7554e04e3dda5996775b345ee6f72f1929b3d3d9/train.py#L397

When using the default `requirements.txt` in provided conda env with `torch==1.13.1+cu116`, pip will install `numpy==1.24.4` by default, which might be the reason. 

See 
- https://github.com/pytorch/pytorch/issues/91516

and it seems to be fixed in PyTorch 2.0+
- https://github.com/pytorch/pytorch/pull/96452

There might exists some better solutions though, thanks for your attention.